### PR TITLE
Implement Prometheus metrics that can be used as an assertion

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,9 +8,18 @@ scalaVersion := "2.12.6"
 
 libraryDependencies += "org.apache.kafka" % "kafka-clients" % "1.1.1" % Provided
 libraryDependencies += "com.typesafe.akka" %% "akka-stream" % "2.5.14"
+libraryDependencies += "com.softwaremill.sttp" %% "core" % "1.2.3"
+libraryDependencies += "com.softwaremill.sttp" %% "async-http-client-backend-future" % "1.2.3"
+libraryDependencies += "org.json4s" %% "json4s-native" % "3.6.0"
 
 libraryDependencies += "com.typesafe.akka" %% "akka-testkit" % "2.5.14" % Test
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5" % Test
 libraryDependencies += "net.manub" %% "scalatest-embedded-kafka" % "1.1.1" % Test
+libraryDependencies += "com.github.tomakehurst" % "wiremock" % "2.18.0" % Test
+libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3" % Test
+
 
 scalacOptions += "-deprecation"
+
+logBuffered in Test := false
+parallelExecution in Test := false

--- a/src/main/scala/io/woodenmill/penstock/Metrics.scala
+++ b/src/main/scala/io/woodenmill/penstock/Metrics.scala
@@ -1,5 +1,12 @@
 package io.woodenmill.penstock
 
+import scala.util.Try
+
 object Metrics {
-  case class Counter(value: Long)
+  implicit val counterFactory: String => Try[Counter] = v => Try(Counter(v.toLong))
+  case class Counter(value: Long) extends Metric[Long]
+}
+
+trait Metric[T] {
+  def value: T
 }

--- a/src/main/scala/io/woodenmill/penstock/backends/kafka/KafkaBackend.scala
+++ b/src/main/scala/io/woodenmill/penstock/backends/kafka/KafkaBackend.scala
@@ -1,5 +1,6 @@
 package io.woodenmill.penstock.backends.kafka
 
+import java.util.UUID
 import java.util.concurrent.TimeUnit.SECONDS
 
 import io.woodenmill.penstock.backends.StreamingBackend
@@ -8,14 +9,12 @@ import org.apache.kafka.common.serialization.ByteArraySerializer
 
 import scala.collection.JavaConverters._
 
-object KafkaBackend {
-  val producerClientId = "penstock-producer"
-}
 
 case class KafkaBackend(bootstrapServers: String) extends StreamingBackend[ProducerRecord[Array[Byte], Array[Byte]]] {
+  private val producerClientId = UUID.randomUUID().toString
   private val config: Map[String, AnyRef] = Map(
     ProducerConfig.BOOTSTRAP_SERVERS_CONFIG -> bootstrapServers,
-    ProducerConfig.CLIENT_ID_CONFIG -> KafkaBackend.producerClientId
+    ProducerConfig.CLIENT_ID_CONFIG -> producerClientId
   )
   private val bytesSerializer = new ByteArraySerializer
   private val producer = new KafkaProducer[Array[Byte], Array[Byte]](config.asJava, bytesSerializer, bytesSerializer)
@@ -24,5 +23,5 @@ case class KafkaBackend(bootstrapServers: String) extends StreamingBackend[Produ
 
   def shutdown(): Unit = producer.close(5, SECONDS)
 
-  def metrics(): KafkaMetrics = KafkaMetrics(producer.metrics().asScala.toMap)
+  def metrics(): KafkaMetrics = KafkaMetrics(producer.metrics().asScala.toMap, producerClientId)
 }

--- a/src/main/scala/io/woodenmill/penstock/backends/kafka/KafkaMetrics.scala
+++ b/src/main/scala/io/woodenmill/penstock/backends/kafka/KafkaMetrics.scala
@@ -7,19 +7,29 @@ import org.apache.kafka.common.{Metric, MetricName}
 import scala.collection.JavaConverters._
 
 object KafkaMetrics {
-  val recordSendTotalName: MetricName = new MetricName("record-send-total", "producer-metrics", "", Map("client-id"->KafkaBackend.producerClientId).asJava)
-  val recordErrorTotalName: MetricName = new MetricName("record-error-total", "producer-metrics", "", Map("client-id"->KafkaBackend.producerClientId).asJava)
+  def recordSendTotalName(clientId: String): MetricName = new MetricName(
+    "record-send-total",
+    "producer-metrics",
+    "",
+    Map("client-id"->clientId).asJava
+  )
+  def recordErrorTotalName(clientId: String): MetricName = new MetricName(
+    "record-error-total",
+    "producer-metrics",
+    "",
+    Map("client-id"->clientId).asJava
+  )
 }
 
-case class KafkaMetrics(rawMetrics: Map[MetricName, Metric]) {
+case class KafkaMetrics(rawMetrics: Map[MetricName, Metric], producerId: String) {
 
   lazy val recordSendTotal: Metrics.Counter = {
-    val totalCount = rawMetrics(recordSendTotalName).metricValue().asInstanceOf[Double]
+    val totalCount = rawMetrics(recordSendTotalName(producerId)).metricValue().asInstanceOf[Double]
     Metrics.Counter(totalCount.toLong)
   }
 
   lazy val recordErrorTotal: Metrics.Counter = {
-    val errorCount = rawMetrics(KafkaMetrics.recordErrorTotalName).metricValue().asInstanceOf[Double]
+    val errorCount = rawMetrics(KafkaMetrics.recordErrorTotalName(producerId)).metricValue().asInstanceOf[Double]
     Metrics.Counter(errorCount.toLong)
   }
 }

--- a/src/main/scala/io/woodenmill/penstock/metrics/prometheus/MetricExtractor.scala
+++ b/src/main/scala/io/woodenmill/penstock/metrics/prometheus/MetricExtractor.scala
@@ -1,0 +1,31 @@
+package io.woodenmill.penstock.metrics.prometheus
+
+import io.woodenmill.penstock.Metric
+import org.json4s.JValue
+import org.json4s.JsonAST.{JArray, JString}
+import org.json4s.native.JsonMethods._
+
+import scala.util.{Failure, Success, Try}
+
+object MetricExtractor {
+
+  def extract[B <: Metric[_]](promResponse: String)(implicit g: String => Try[B]): Try[B] = {
+    parseOpt(promResponse).map(Success(_)).getOrElse(Failure(new IllegalArgumentException("Not a valid JSON")))
+      .map(extractResult)
+      .flatMap(extractMetricValue)
+      .flatMap {
+        case JString(value) => Try(value)
+        case value => Failure(new IllegalArgumentException(s"Invalid response from Prometheus. Unparsable metric value: $value"))
+      }
+      .flatMap(g)
+  }
+
+  private val extractResult: JValue => JValue = bodyJson => bodyJson \ "data" \ "result"
+
+  private val extractMetricValue: JValue => Try[JValue] = {
+    case JArray(value :: Nil) => Try((value \ "value") (1))
+    case JArray(Nil) => Failure(new IllegalArgumentException("Metric does not exist"))
+    case JArray(h :: tail) => Failure(new IllegalArgumentException("Prom Query returned more than one metric. Correct your query so it fetch only one metric"))
+  }
+
+}

--- a/src/main/scala/io/woodenmill/penstock/metrics/prometheus/PrometheusClient.scala
+++ b/src/main/scala/io/woodenmill/penstock/metrics/prometheus/PrometheusClient.scala
@@ -1,0 +1,38 @@
+package io.woodenmill.penstock.metrics.prometheus
+
+import com.softwaremill.sttp._
+import com.softwaremill.sttp.asynchttpclient.future.AsyncHttpClientFutureBackend
+import io.woodenmill.penstock.Metrics
+import io.woodenmill.penstock.Metrics._
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Success, Try}
+
+
+
+object Prometheus {
+
+  case class PrometheusConfig(prometheusUrl: Uri)
+
+  object PromQl {
+    def apply(queryToParse: String): Try[PromQl] = Success(new PromQl(queryToParse))
+  }
+
+  case class PromQl(query: String)
+}
+
+
+case class PrometheusClient(config: Prometheus.PrometheusConfig) {
+  private implicit val backend = AsyncHttpClientFutureBackend()
+
+  def fetch(query: Prometheus.PromQl)(implicit ec: ExecutionContext): Future[Metrics.Counter] = {
+    val promApi = config.prometheusUrl.path("/api/v1/query")
+    val request = sttp.get(promApi.param("query", query.query))
+    request.send().flatMap {
+      case Response(body: Right[_, String], code, _, _, _) =>
+        val bodyString = body.value
+
+        Future.fromTry( MetricExtractor.extract[Counter](bodyString) )
+    }
+  }
+}

--- a/src/main/scala/io/woodenmill/penstock/metrics/prometheus/PrometheusMetric.scala
+++ b/src/main/scala/io/woodenmill/penstock/metrics/prometheus/PrometheusMetric.scala
@@ -1,0 +1,39 @@
+package io.woodenmill.penstock.metrics.prometheus
+
+
+import akka.actor.{Actor, ActorLogging, ActorRef, ActorSystem, Props}
+import akka.pattern.{ask, pipe}
+import akka.util.Timeout
+import io.woodenmill.penstock.Metric
+import io.woodenmill.penstock.metrics.prometheus.MetricFetcher.{Fetch, RespondMetric}
+import io.woodenmill.penstock.metrics.prometheus.Prometheus.PromQl
+import scala.concurrent.duration._
+
+import scala.concurrent.{Await, ExecutionContext}
+
+case class PrometheusMetric[T <: Metric[_]](query: PromQl)(implicit config: Prometheus.PrometheusConfig, actorSystem: ActorSystem) {
+  private implicit val askTimeout: Timeout = Timeout(5.seconds)
+  private val fetcher: ActorRef = actorSystem.actorOf(MetricFetcher.props(query, config))
+
+  def value(): Long = Await.result(fetcher.ask(MetricFetcher.Fetch()).mapTo[RespondMetric], 1.second).value
+}
+
+
+object MetricFetcher {
+  def props(query: PromQl, config: Prometheus.PrometheusConfig): Props = Props(new MetricFetcher(query, config))
+
+  final case class Fetch()
+  final case class RespondMetric(value: Long)
+}
+
+class MetricFetcher(query: PromQl, config: Prometheus.PrometheusConfig) extends Actor with ActorLogging {
+  implicit val ec: ExecutionContext = context.dispatcher
+  val promClient: PrometheusClient = PrometheusClient(config)
+
+  override def receive: Receive = {
+    case Fetch() =>
+      val eventualMetric = promClient.fetch(query)
+      eventualMetric.map(m => RespondMetric(m.value)) pipeTo sender()
+  }
+
+}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,12 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="OFF">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/src/test/scala/io/woodenmill/penstock/backends/kafka/KafkaBackendSpec.scala
+++ b/src/test/scala/io/woodenmill/penstock/backends/kafka/KafkaBackendSpec.scala
@@ -3,6 +3,7 @@ package io.woodenmill.penstock.backends.kafka
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import io.woodenmill.penstock.LoadRunner
+import io.woodenmill.penstock.testutils.Ports
 import net.manub.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.serialization.StringDeserializer
@@ -10,14 +11,17 @@ import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 
 import scala.concurrent.duration._
+import scala.util.Try
 
 class KafkaBackendSpec extends FlatSpec with Matchers with EmbeddedKafka with BeforeAndAfterAll with ScalaFutures with Eventually {
 
-  val topic = "input"
-  val kafkaPort = 6001
-  val kafkaBackend: KafkaBackend = KafkaBackend(s"localhost:$kafkaPort")
+  val topic: String = "input"
+  val kafkaPort: Int = Ports.nextAvailablePort()
+  val bootstrapServer: String = s"localhost:$kafkaPort"
+
+  val kafkaBackend: KafkaBackend = KafkaBackend(bootstrapServer)
   implicit val stringDeserializer = new StringDeserializer()
-  implicit val kafkaConfig = EmbeddedKafkaConfig(kafkaPort = kafkaPort)
+  implicit val kafkaConfig = EmbeddedKafkaConfig(kafkaPort = kafkaPort, zooKeeperPort = Ports.nextAvailablePort())
   implicit val testPatienceConfig: PatienceConfig = PatienceConfig(timeout = 2.seconds)
 
   override protected def beforeAll(): Unit = {
@@ -57,9 +61,8 @@ class KafkaBackendSpec extends FlatSpec with Matchers with EmbeddedKafka with Be
     }
   }
 
-  it should "expose basic Kafka Producer metrics" in {
+  it should "expose basic Kafka Producer metrics" in withNewKafkaBackend(bootstrapServer){ backend =>
     //given
-    val backend = KafkaBackend(s"localhost:$kafkaPort")
     val someMessage = new ProducerRecord[Array[Byte], Array[Byte]](topic, "some message".getBytes)
 
     //when
@@ -74,12 +77,14 @@ class KafkaBackendSpec extends FlatSpec with Matchers with EmbeddedKafka with Be
     }
   }
 
-  it should "expose metrics before any message is sent" in {
-    //when
-    val backend = KafkaBackend(s"localhost:$kafkaPort")
-
-    //then
+  it should "expose metrics before any message is sent" in withNewKafkaBackend(bootstrapServer){ backend =>
     backend.metrics().recordSendTotal.value shouldBe 0
+  }
+
+  def withNewKafkaBackend(bootstrapServer: String)(f: KafkaBackend => Unit): Unit = {
+    val backend = KafkaBackend(bootstrapServer)
+    Try( f(backend) )
+    backend.shutdown()
   }
 
 }

--- a/src/test/scala/io/woodenmill/penstock/examples/GettingStartedSpec.scala
+++ b/src/test/scala/io/woodenmill/penstock/examples/GettingStartedSpec.scala
@@ -1,0 +1,62 @@
+package io.woodenmill.penstock.examples
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import com.softwaremill.sttp._
+import io.woodenmill.penstock.LoadRunner
+import io.woodenmill.penstock.Metrics.Counter
+import io.woodenmill.penstock.backends.kafka.KafkaBackend
+import io.woodenmill.penstock.metrics.prometheus.Prometheus.{PromQl, PrometheusConfig}
+import io.woodenmill.penstock.metrics.prometheus.PrometheusMetric
+import io.woodenmill.penstock.testutils.{Ports, PromResponses, PrometheusIntegratedSpec}
+import net.manub.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.scalatest.{AsyncFlatSpec, Matchers}
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class GettingStartedSpec extends AsyncFlatSpec with Matchers with EmbeddedKafka with PrometheusIntegratedSpec {
+
+  val topic: String = "examples"
+  val kafkaPort: Int = Ports.nextAvailablePort()
+
+  implicit val kafkaConfig: EmbeddedKafkaConfig = EmbeddedKafkaConfig(kafkaPort = kafkaPort, zooKeeperPort = Ports.nextAvailablePort())
+
+  implicit val kafkaBackend: KafkaBackend = KafkaBackend(s"localhost:$kafkaPort")
+  implicit val system: ActorSystem = ActorSystem("Getting-Started")
+  implicit val mat: ActorMaterializer = ActorMaterializer()
+  implicit val promConfig: PrometheusConfig = PrometheusConfig(uri"localhost:$promPort")
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    EmbeddedKafka.start()(kafkaConfig)
+    createCustomTopic(topic)
+  }
+
+
+  "Getting Started" should "send messages to Kafka and use custom Prometheus metric to verify behaviour" in {
+    //given
+    configurePromStub("up", PromResponses.valid("1"))
+    val testMessage = new ProducerRecord[Array[Byte], Array[Byte]](topic, "test message".getBytes)
+    val customMetric = PrometheusMetric[Counter](PromQl("up").get)
+
+    //when
+    val loadFinished = LoadRunner(testMessage, duration = 3.seconds, throughput = 200).run()
+
+    //then
+    loadFinished.map { _ =>
+      kafkaBackend.metrics().recordErrorTotal.value shouldBe 0
+      kafkaBackend.metrics().recordSendTotal.value should be (600L +- 50L)
+      customMetric.value() shouldBe 1
+    }
+  }
+
+  override protected def afterAll(): Unit = {
+    Await.ready(system.terminate(), 5.seconds)
+    kafkaBackend.shutdown()
+    EmbeddedKafka.stop()
+    super.afterAll()
+  }
+
+}

--- a/src/test/scala/io/woodenmill/penstock/metrics/prometheus/MetricExtractorSpec.scala
+++ b/src/test/scala/io/woodenmill/penstock/metrics/prometheus/MetricExtractorSpec.scala
@@ -1,0 +1,49 @@
+package io.woodenmill.penstock.metrics.prometheus
+
+import io.woodenmill.penstock.Metrics.{Counter, _}
+import io.woodenmill.penstock.testutils.PromResponses
+import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.TryValues._
+
+import scala.util.Success
+
+class MetricExtractorSpec extends FlatSpec with Matchers {
+
+  "MetricExtractor" should "extract a single metric from Prometheus Api response" in {
+    val counter = MetricExtractor.extract[Counter](PromResponses.valid("44"))
+
+    counter shouldBe Success(Counter(44L))
+  }
+
+  it should "extract negative values" in {
+    val extracted = MetricExtractor.extract[Counter](PromResponses.responseWithNegativeValue)
+
+    extracted shouldBe Success(Counter(-1L))
+  }
+
+  it should "return Failure if response is invalid" in {
+    val invalidResponse = "Not found"
+
+    val extracted = MetricExtractor.extract[Counter](invalidResponse)
+
+    extracted.failure.exception should have message "Not a valid JSON"
+  }
+
+  it should "return Failure if response contains more than 1 metric" in {
+    val extracted = MetricExtractor.extract[Counter](PromResponses.multipleMetricsResponse())
+
+    extracted.failure.exception should have message "Prom Query returned more than one metric. Correct your query so it fetch only one metric"
+  }
+
+  it should "return Failure if queried metrics does not exist" in {
+    val extracted = MetricExtractor.extract[Counter](PromResponses.noDataPoint)
+
+    extracted.failure.exception should have message "Metric does not exist"
+  }
+
+  it should "return Failure if metric value is not a String" in {
+    val extracted = MetricExtractor.extract[Counter](PromResponses.invalidValue)
+
+    extracted.failure.exception should have message "Invalid response from Prometheus. Unparsable metric value: JInt(3)"
+  }
+}

--- a/src/test/scala/io/woodenmill/penstock/metrics/prometheus/PrometheusClientSpec.scala
+++ b/src/test/scala/io/woodenmill/penstock/metrics/prometheus/PrometheusClientSpec.scala
@@ -1,0 +1,31 @@
+package io.woodenmill.penstock.metrics.prometheus
+
+import com.softwaremill.sttp._
+import io.woodenmill.penstock.metrics.prometheus.Prometheus.{PromQl, PrometheusConfig}
+import io.woodenmill.penstock.testutils.{PromResponses, PrometheusIntegratedSpec}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+
+
+class PrometheusClientSpec extends FlatSpec with ScalaFutures with PrometheusIntegratedSpec with Matchers {
+  implicit override val patienceConfig: PatienceConfig = PatienceConfig(timeout = 2.seconds)
+
+  "Prometheus client" should "fetch metric value from Prometheus" in {
+    //given
+    val query = "up"
+    configurePromStub(query, PromResponses.valid("5"))
+
+    //when
+    val metricFuture = PrometheusClient(PrometheusConfig(uri"localhost:$promPort")).fetch(PromQl(query).get)
+
+    //then
+    whenReady(metricFuture) { metric =>
+      metric.value shouldBe 5
+    }
+  }
+
+}
+

--- a/src/test/scala/io/woodenmill/penstock/metrics/prometheus/PrometheusMetricSpec.scala
+++ b/src/test/scala/io/woodenmill/penstock/metrics/prometheus/PrometheusMetricSpec.scala
@@ -1,0 +1,44 @@
+package io.woodenmill.penstock.metrics.prometheus
+
+import akka.actor.ActorSystem
+import com.softwaremill.sttp._
+import io.woodenmill.penstock.Metrics.Counter
+import io.woodenmill.penstock.metrics.prometheus.Prometheus.{PromQl, PrometheusConfig}
+import io.woodenmill.penstock.testutils.PromResponses.valid
+import io.woodenmill.penstock.testutils.PrometheusIntegratedSpec
+import org.scalatest.concurrent.Eventually
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.concurrent.duration._
+
+class PrometheusMetricSpec extends FlatSpec with Matchers with PrometheusIntegratedSpec with Eventually {
+
+  override implicit def patienceConfig: PatienceConfig = PatienceConfig(timeout = 2.seconds)
+
+  val actorSystem = ActorSystem()
+  val promConfig = PrometheusConfig(uri"localhost:$promPort")
+
+  "PrometheusMetric" should "fetch the value from Prometheus" in {
+    //given
+    configurePromStub("up", valid("7"))
+
+    //when
+    val prometheusMetric = PrometheusMetric[Counter](PromQl("up").get)(promConfig, actorSystem)
+
+    //then
+    prometheusMetric.value shouldBe 7
+  }
+
+  it should "fetch a metric periodically" in {
+    //given
+    configurePromStub("sum(up)", valid("1"), valid("2"), valid("3"))
+
+    //when
+    val prometheusMetric = PrometheusMetric[Counter](PromQl("sum(up)").get)(promConfig, actorSystem)
+
+    //then
+    eventually {
+      prometheusMetric.value() shouldBe 3
+    }
+  }
+}

--- a/src/test/scala/io/woodenmill/penstock/testutils/Ports.scala
+++ b/src/test/scala/io/woodenmill/penstock/testutils/Ports.scala
@@ -1,0 +1,14 @@
+package io.woodenmill.penstock.testutils
+
+import java.net.ServerSocket
+
+object Ports {
+
+  def nextAvailablePort(): Int = {
+    val socket = new ServerSocket(0)
+    socket.setReuseAddress(true)
+    val port = socket.getLocalPort
+    socket.close()
+    port
+  }
+}

--- a/src/test/scala/io/woodenmill/penstock/testutils/PromResponses.scala
+++ b/src/test/scala/io/woodenmill/penstock/testutils/PromResponses.scala
@@ -1,0 +1,121 @@
+package io.woodenmill.penstock.testutils
+
+
+  object PromResponses {
+    val noDataPoint: String =
+      """
+        |{
+        | "status": "success",
+        | "data": {
+        |   "resultType": "vector",
+        |   "result": []
+        | }
+        |}
+      """.stripMargin
+
+    def responseWithNegativeValue: String =
+    """
+      |{
+      | "status": "success",
+      | "data": {
+      |   "resultType": "vector",
+      |   "result": [
+      |     {
+      |       "metric": {
+      |         "__name__": "jvm_memory_bytes_max",
+      |         "area": "nonheap",
+      |         "instance": "kafka:7071",
+      |         "job": "kafka"
+      |     },
+      |   "value": [
+      |     1533934927.769,
+      |     "-1"
+      |   ]
+      |  }
+      | ]
+      | }
+      |}
+    """.stripMargin
+
+    def valid(metricValue: String): String =
+      s"""
+         |{
+         | "status": "success",
+         | "data": {
+         |   "resultType": "vector",
+         |   "result": [
+         |     {
+         |       "metric": {
+         |         "instance": "kafka:7071",
+         |         "job": "kafka",
+         |         "topic": "test"
+         |       },
+         |       "value": [
+         |         1533765030.363,
+         |         "$metricValue"
+         |       ]
+         |     }
+         |   ]
+         | }
+         |}
+    """.stripMargin
+
+
+    val invalidValue: String =
+      s"""
+         |{
+         | "status": "success",
+         | "data": {
+         |   "resultType": "vector",
+         |   "result": [
+         |     {
+         |       "metric": {
+         |         "instance": "kafka:7071",
+         |         "job": "kafka",
+         |         "topic": "test"
+         |       },
+         |       "value": [
+         |         1533765030.363,
+         |         3
+         |       ]
+         |     }
+         |   ]
+         | }
+         |}
+    """.stripMargin
+
+    def multipleMetricsResponse(): String =
+      s"""
+         |{
+         | "status": "success",
+         | "data": {
+         |   "resultType": "vector",
+         |   "result": [
+         |     {
+         |       "metric": {
+         |         "instance": "kafka:7071",
+         |         "job": "kafka",
+         |         "topic": "test"
+         |       },
+         |       "value": [
+         |         1533765030.363,
+         |         "1"
+         |       ]
+         |     },
+         |     {
+         |       "metric": {
+         |         "instance": "kafka:7071",
+         |         "job": "kafka",
+         |         "topic": "test"
+         |       },
+         |       "value": [
+         |         1533765030.363,
+         |         "2"
+         |       ]
+         |     }
+         |   ]
+         | }
+         |}
+    """.stripMargin
+
+  }

--- a/src/test/scala/io/woodenmill/penstock/testutils/PrometheusIntegratedSpec.scala
+++ b/src/test/scala/io/woodenmill/penstock/testutils/PrometheusIntegratedSpec.scala
@@ -1,0 +1,46 @@
+package io.woodenmill.penstock.testutils
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import com.github.tomakehurst.wiremock.stubbing.Scenario
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, Suite}
+
+trait PrometheusIntegratedSpec extends BeforeAndAfterAll with BeforeAndAfter { this: Suite =>
+  val promPort: Int = Ports.nextAvailablePort()
+  val wireMockServer = new WireMockServer(WireMockConfiguration.options().port(promPort))
+
+
+  before {
+    wireMockServer.resetAll()
+  }
+
+  override protected def beforeAll(): Unit = {
+    wireMockServer.start()
+    configureFor("localhost", promPort)
+  }
+
+  override protected def afterAll(): Unit = wireMockServer.stop()
+
+  def configurePromStub(query: String, promResponse: String): Unit = {
+    stubFor(get(urlPathEqualTo("/api/v1/query")).withQueryParam("query", equalTo(query))
+      .willReturn(aResponse.withStatus(200).withBody(promResponse))
+    )
+  }
+
+  def configurePromStub(query: String, firstResponse: String, nextResponses: String*): Unit = {
+    stubFor(get(urlPathEqualTo("/api/v1/query")).withQueryParam("query", equalTo(query))
+      .inScenario(query).whenScenarioStateIs(Scenario.STARTED).willSetStateTo("0")
+      .willReturn(aResponse.withStatus(200).withBody(firstResponse))
+    )
+
+    nextResponses.zipWithIndex.foreach { case (response, stepId) => {
+      stubFor(get(urlPathEqualTo("/api/v1/query")).withQueryParam("query", equalTo(query))
+        .inScenario(query).whenScenarioStateIs(stepId.toString).willSetStateTo((stepId+1).toString)
+        .willReturn(aResponse.withStatus(200).withBody(response))
+      )
+    }}
+
+  }
+
+}


### PR DESCRIPTION
The idea of this building block is that in Streaming Nft we must use externally collected metrics as an assertion. Load Runner metrics can be useful to do a sanity check, but the proper assertion must be done based on external metrics. PrometheusMetric is responsible for querying Prometheus API and returning metric's value to the test.