### PR TITLE
Add support for Gauge metric

### DIFF
--- a/src/main/scala/io/woodenmill/penstock/Metrics.scala
+++ b/src/main/scala/io/woodenmill/penstock/Metrics.scala
@@ -3,8 +3,14 @@ package io.woodenmill.penstock
 import scala.util.Try
 
 object Metrics {
+  type MetricFactory[B] = String => Try[B]
+
   implicit val counterFactory: String => Try[Counter] = v => Try(Counter(v.toLong))
   case class Counter(value: Long) extends Metric[Long]
+
+  implicit val gaugeFactory: String => Try[Gauge] = v => Try(Gauge(v.toDouble))
+  case class Gauge(value: Double) extends Metric[Double]
+
 }
 
 trait Metric[T] {

--- a/src/main/scala/io/woodenmill/penstock/metrics/prometheus/MetricExtractor.scala
+++ b/src/main/scala/io/woodenmill/penstock/metrics/prometheus/MetricExtractor.scala
@@ -1,6 +1,7 @@
 package io.woodenmill.penstock.metrics.prometheus
 
 import io.woodenmill.penstock.Metric
+import io.woodenmill.penstock.Metrics.MetricFactory
 import org.json4s.JValue
 import org.json4s.JsonAST.{JArray, JString}
 import org.json4s.native.JsonMethods._
@@ -9,7 +10,7 @@ import scala.util.{Failure, Success, Try}
 
 object MetricExtractor {
 
-  def extract[B <: Metric[_]](promResponse: String)(implicit g: String => Try[B]): Try[B] = {
+  def extract[B <: Metric[_]](promResponse: String)(implicit g: MetricFactory[B]): Try[B] = {
     parseOpt(promResponse).map(Success(_)).getOrElse(Failure(new IllegalArgumentException("Not a valid JSON")))
       .map(extractResult)
       .flatMap(extractMetricValue)

--- a/src/main/scala/io/woodenmill/penstock/metrics/prometheus/PrometheusClient.scala
+++ b/src/main/scala/io/woodenmill/penstock/metrics/prometheus/PrometheusClient.scala
@@ -1,37 +1,40 @@
 package io.woodenmill.penstock.metrics.prometheus
 
 import java.net.URI
+
 import com.softwaremill.sttp._
 import com.softwaremill.sttp.asynchttpclient.future.AsyncHttpClientFutureBackend
-import io.woodenmill.penstock.Metrics
+import io.woodenmill.penstock.Metric
 import io.woodenmill.penstock.Metrics._
+import io.woodenmill.penstock.metrics.prometheus.Prometheus.PromQl
+
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Success, Try}
 
 
 object Prometheus {
 
   case class PrometheusConfig(prometheusUrl: URI)
 
-  object PromQl {
-    def apply(queryToParse: String): Try[PromQl] = Success(new PromQl(queryToParse))
+  case class PromQl[M <: Metric[_]](query: String, metricFactory: MetricFactory[M]) {
+    override def toString: String = s"query=$query"
   }
 
-  case class PromQl(query: String)
 }
 
 
 case class PrometheusClient(config: Prometheus.PrometheusConfig) {
   private implicit val backend = AsyncHttpClientFutureBackend()
 
-  def fetch(query: Prometheus.PromQl)(implicit ec: ExecutionContext): Future[Metrics.Counter] = {
+  def fetch[B <: Metric[_]](query: PromQl[B])(implicit ec: ExecutionContext): Future[B] = {
     val promApi = Uri(config.prometheusUrl).path("/api/v1/query")
     val request = sttp.get(promApi.param("query", query.query))
+
     request.send().flatMap {
       case r @ Response(Right(body), code, _, _, _) if r.isSuccess =>
-        Future.fromTry( MetricExtractor.extract[Counter](body) )
+        val triedCounter = MetricExtractor.extract[B](body)(query.metricFactory)
+        Future.fromTry( triedCounter )
       case Response(Left(body), code, _, _, _) =>
-        Future.failed(new RuntimeException(s"Querying Prometheus has failed. Query: $query. Response: status=$code, body=${new String(body)}"))
+        Future.failed(new RuntimeException(s"Querying Prometheus has failed. $query. Response: status=$code, body=${new String(body)}"))
     }
   }
 }

--- a/src/main/scala/io/woodenmill/penstock/metrics/prometheus/PrometheusMetric.scala
+++ b/src/main/scala/io/woodenmill/penstock/metrics/prometheus/PrometheusMetric.scala
@@ -7,33 +7,33 @@ import akka.util.Timeout
 import io.woodenmill.penstock.Metric
 import io.woodenmill.penstock.metrics.prometheus.MetricFetcher.{Fetch, RespondMetric}
 import io.woodenmill.penstock.metrics.prometheus.Prometheus.PromQl
+
 import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext, Future}
 
-import scala.concurrent.{Await, ExecutionContext}
-
-case class PrometheusMetric[T <: Metric[_]](query: PromQl)(implicit config: Prometheus.PrometheusConfig, actorSystem: ActorSystem) {
+case class PrometheusMetric[T <: Metric[_]](query: PromQl[T])(implicit config: Prometheus.PrometheusConfig, actorSystem: ActorSystem) {
   private implicit val askTimeout: Timeout = Timeout(5.seconds)
   private val fetcher: ActorRef = actorSystem.actorOf(MetricFetcher.props(query, config))
 
-  def value(): Long = Await.result(fetcher.ask(MetricFetcher.Fetch()).mapTo[RespondMetric], 1.second).value
+  def value(): T = Await.result(fetcher.ask(MetricFetcher.Fetch()).mapTo[RespondMetric[T]], 1.second).value
 }
 
 
 object MetricFetcher {
-  def props(query: PromQl, config: Prometheus.PrometheusConfig): Props = Props(new MetricFetcher(query, config))
+  def props[M <: Metric[_]](query: PromQl[M], config: Prometheus.PrometheusConfig): Props = Props(new MetricFetcher(query, config))
 
   final case class Fetch()
-  final case class RespondMetric(value: Long)
+  final case class RespondMetric[T](value: T)
 }
 
-class MetricFetcher(query: PromQl, config: Prometheus.PrometheusConfig) extends Actor with ActorLogging {
+class MetricFetcher[M <: Metric[_]](query: PromQl[M], config: Prometheus.PrometheusConfig) extends Actor with ActorLogging {
   implicit val ec: ExecutionContext = context.dispatcher
   val promClient: PrometheusClient = PrometheusClient(config)
 
   override def receive: Receive = {
     case Fetch() =>
-      val eventualMetric = promClient.fetch(query)
-      eventualMetric.map(m => RespondMetric(m.value)) pipeTo sender()
+      val eventualMetric: Future[M] = promClient.fetch[M](query)(ec)
+      eventualMetric.map(m => RespondMetric[M](m)) pipeTo sender()
   }
 
 }

--- a/src/test/scala/io/woodenmill/penstock/metrics/prometheus/PrometheusClientSpec.scala
+++ b/src/test/scala/io/woodenmill/penstock/metrics/prometheus/PrometheusClientSpec.scala
@@ -1,5 +1,7 @@
 package io.woodenmill.penstock.metrics.prometheus
 
+import io.woodenmill.penstock.Metrics
+import io.woodenmill.penstock.Metrics.Counter
 import io.woodenmill.penstock.metrics.prometheus.Prometheus.{PromQl, PrometheusConfig}
 import io.woodenmill.penstock.testutils.{PromResponses, PrometheusIntegratedSpec}
 import org.scalatest.concurrent.ScalaFutures
@@ -18,7 +20,7 @@ class PrometheusClientSpec extends FlatSpec with ScalaFutures with PrometheusInt
     configurePromStub(query, PromResponses.valid("5"))
 
     //when
-    val metricFuture = PrometheusClient(PrometheusConfig(prometheusUri)).fetch(PromQl(query).get)
+    val metricFuture = PrometheusClient(PrometheusConfig(prometheusUri)).fetch(PromQl[Counter](query, Metrics.counterFactory))
 
     //then
     whenReady(metricFuture) { metric =>
@@ -31,11 +33,11 @@ class PrometheusClientSpec extends FlatSpec with ScalaFutures with PrometheusInt
     configurePromStub("up", "Not found", 404)
 
     //when
-    val metricFuture = PrometheusClient(PrometheusConfig(prometheusUri)).fetch(PromQl("up").get)
+    val metricFuture = PrometheusClient(PrometheusConfig(prometheusUri)).fetch(PromQl[Counter]("up", Metrics.counterFactory))
 
     //then
     whenReady(metricFuture.failed) { ex =>
-      ex should have message "Querying Prometheus has failed. Query: PromQl(up). Response: status=404, body=Not found"
+      ex should have message "Querying Prometheus has failed. query=up. Response: status=404, body=Not found"
     }
   }
 

--- a/src/test/scala/io/woodenmill/penstock/metrics/prometheus/PrometheusMetricSpec.scala
+++ b/src/test/scala/io/woodenmill/penstock/metrics/prometheus/PrometheusMetricSpec.scala
@@ -1,7 +1,8 @@
 package io.woodenmill.penstock.metrics.prometheus
 
 import akka.actor.ActorSystem
-import io.woodenmill.penstock.Metrics.Counter
+import io.woodenmill.penstock.Metrics
+import io.woodenmill.penstock.Metrics.{Counter, Gauge}
 import io.woodenmill.penstock.metrics.prometheus.Prometheus.{PromQl, PrometheusConfig}
 import io.woodenmill.penstock.testutils.PromResponses.valid
 import io.woodenmill.penstock.testutils.PrometheusIntegratedSpec
@@ -18,26 +19,28 @@ class PrometheusMetricSpec extends FlatSpec with Matchers with PrometheusIntegra
   val promConfig = PrometheusConfig(prometheusUri)
 
   "PrometheusMetric" should "fetch the value from Prometheus" in {
-    //given
     configurePromStub("up", valid("7"))
 
-    //when
-    val prometheusMetric = PrometheusMetric[Counter](PromQl("up").get)(promConfig, actorSystem)
+    val prometheusMetric = PrometheusMetric[Counter](PromQl[Counter]("up", Metrics.counterFactory))(promConfig, actorSystem)
 
-    //then
-    prometheusMetric.value shouldBe 7
+    prometheusMetric.value shouldBe Counter(7)
+  }
+
+  it should "support Gauge metric" in {
+    configurePromStub("messagesRate", valid("198.2876758707929"))
+
+    val prometheusMetric = PrometheusMetric[Gauge](PromQl("messagesRate", Metrics.gaugeFactory))(promConfig, actorSystem)
+
+    prometheusMetric.value().value shouldBe 198.287 +- 0.1
   }
 
   it should "fetch a metric periodically" in {
-    //given
     configurePromStub("sum(up)", valid("1"), valid("2"), valid("3"))
 
-    //when
-    val prometheusMetric = PrometheusMetric[Counter](PromQl("sum(up)").get)(promConfig, actorSystem)
+    val prometheusMetric = PrometheusMetric[Counter](PromQl("sum(up)", Metrics.counterFactory))(promConfig, actorSystem)
 
-    //then
     eventually {
-      prometheusMetric.value() shouldBe 3
+      prometheusMetric.value().value shouldBe 3
     }
   }
 }


### PR DESCRIPTION
Penstock must support all kinds of common metrics: counters, gauges, histograms. This commit generalize metric logic and introduce a second metric type - gauges.