### PR TITLE
Separate library tests from usage examples.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: scala
 scala:
    - 2.12.6
 jdk: oraclejdk8
-script: sbt ++$TRAVIS_SCALA_VERSION clean coverage test coverageReport codacyCoverage
+script: sbt ++$TRAVIS_SCALA_VERSION clean coverage test it:compile coverageReport codacyCoverage

--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,12 @@ version := "0.0.1-SNAPSHOT"
 
 scalaVersion := "2.12.6"
 
+lazy val IntegrationTest = config("it") extend Test
+
+lazy val root = project.in(file("."))
+    .configs( IntegrationTest )
+    .settings( Defaults.itSettings : _*)
+
 libraryDependencies += "org.apache.kafka" % "kafka-clients" % "1.1.1" % Provided
 libraryDependencies += "com.typesafe.akka" %% "akka-stream" % "2.5.14"
 libraryDependencies += "com.softwaremill.sttp" %% "core" % "1.2.3"

--- a/src/it/scala/io/woodenmill/penstock/examples/GettingStartedSpec.scala
+++ b/src/it/scala/io/woodenmill/penstock/examples/GettingStartedSpec.scala
@@ -4,11 +4,11 @@ import java.net.URI
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
-import io.woodenmill.penstock.{LoadRunner, Metrics}
-import io.woodenmill.penstock.Metrics.{Counter, MetricFactory}
+import io.woodenmill.penstock.Metrics.{Gauge, MetricFactory}
 import io.woodenmill.penstock.backends.kafka.KafkaBackend
 import io.woodenmill.penstock.metrics.prometheus.Prometheus.{PromQl, PrometheusConfig}
 import io.woodenmill.penstock.metrics.prometheus.PrometheusMetric
+import io.woodenmill.penstock.{LoadRunner, Metrics}
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.scalatest.{AsyncFlatSpec, Matchers}
 
@@ -16,29 +16,28 @@ import scala.concurrent.duration._
 
 class GettingStartedSpec extends AsyncFlatSpec with Matchers  {
 
-
   implicit val system: ActorSystem = ActorSystem("Getting-Started")
   implicit val mat: ActorMaterializer = ActorMaterializer()
   implicit val kafkaBackend: KafkaBackend = KafkaBackend("localhost:9092")
   implicit val promConfig: PrometheusConfig = PrometheusConfig(new URI("localhost:9090"))
-  val mf: MetricFactory[Counter] = Metrics.counterFactory
+  val mf: MetricFactory[Gauge] = Metrics.gaugeFactory
 
 
-  ignore should "send messages to Kafka and use custom Prometheus metric to verify behaviour" in {
+  "GettingStarted example" should "send messages to Kafka and use custom Prometheus metric to verify behaviour" in {
     //given
     val topic: String = "input"
     val testMessage = new ProducerRecord[Array[Byte], Array[Byte]](topic, "test message".getBytes)
-    val query = PromQl(s"""kafka_server_BrokerTopicMetrics_OneMinuteRate{name="MessagesInPerSec",topic="$topic"}""", mf)
-    val kafkaTopicMessagesRate = PrometheusMetric[Counter](query)
+    val query = PromQl[Gauge](s"""kafka_server_BrokerTopicMetrics_OneMinuteRate{name="MessagesInPerSec",topic="$topic"}""", mf)
+    val kafkaTopicMessagesRate = PrometheusMetric[Gauge](query)
 
     //when
-    val loadFinished = LoadRunner(testMessage, duration = 5.minutes, throughput = 200).run()
+    val loadFinished = LoadRunner(testMessage, duration = 2.minutes, throughput = 200).run()
 
     //then
     loadFinished.map { _ =>
       kafkaBackend.metrics().recordErrorTotal.value shouldBe 0
-      kafkaBackend.metrics().recordSendTotal.value should be (60000L +- 1000L)
-      kafkaTopicMessagesRate.value() shouldBe 200L +- 20L
+      kafkaBackend.metrics().recordSendTotal.value should be (24000L +- 1000L)
+      kafkaTopicMessagesRate.value().value shouldBe 200.0 +- 20.0
     }
   }
 


### PR DESCRIPTION
GettingStartedSpec is meant to provide an example of library usage. That is why duration of the test is close to real world examples and cannot be a part of build process. The example spec was moved to integration tests directory and `sbt test` does not run it.

Closes #6 