### PR TITLE
Add KafkaMessage case class that simplify creation of ProducerRecord

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,8 @@ lazy val root = project.in(file("."))
     .configs( IntegrationTest )
     .settings( Defaults.itSettings : _*)
 
+resolvers += Resolver.bintrayRepo("ovotech", "maven")
+
 libraryDependencies += "org.apache.kafka" % "kafka-clients" % "1.1.1" % Provided
 libraryDependencies += "com.typesafe.akka" %% "akka-stream" % "2.5.14"
 libraryDependencies += "com.softwaremill.sttp" %% "core" % "1.2.3"
@@ -23,6 +25,10 @@ libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5" % Test
 libraryDependencies += "net.manub" %% "scalatest-embedded-kafka" % "1.1.1" % Test
 libraryDependencies += "com.github.tomakehurst" % "wiremock" % "2.18.0" % Test
 libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3" % Test
+libraryDependencies += "io.circe" %% "circe-core" % "0.8.0" % Test
+libraryDependencies += "io.circe" %% "circe-generic" % "0.8.0" % Test
+libraryDependencies += "com.ovoenergy" %% "kafka-serialization-core" % "0.3.11" % Test
+libraryDependencies += "com.ovoenergy" %% "kafka-serialization-circe" % "0.3.11" % Test
 
 
 scalacOptions ++= Seq(

--- a/src/it/scala/io/woodenmill/penstock/examples/GettingStartedSpec.scala
+++ b/src/it/scala/io/woodenmill/penstock/examples/GettingStartedSpec.scala
@@ -5,11 +5,11 @@ import java.net.URI
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import io.woodenmill.penstock.Metrics.{Gauge, MetricFactory}
-import io.woodenmill.penstock.backends.kafka.KafkaBackend
+import io.woodenmill.penstock.backends.kafka.{KafkaBackend, KafkaMessage}
 import io.woodenmill.penstock.metrics.prometheus.Prometheus.{PromQl, PrometheusConfig}
 import io.woodenmill.penstock.metrics.prometheus.PrometheusMetric
 import io.woodenmill.penstock.{LoadRunner, Metrics}
-import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.serialization.{Serializer, StringSerializer}
 import org.scalatest.{AsyncFlatSpec, Matchers}
 
 import scala.concurrent.duration._
@@ -20,13 +20,14 @@ class GettingStartedSpec extends AsyncFlatSpec with Matchers  {
   implicit val mat: ActorMaterializer = ActorMaterializer()
   implicit val kafkaBackend: KafkaBackend = KafkaBackend("localhost:9092")
   implicit val promConfig: PrometheusConfig = PrometheusConfig(new URI("localhost:9090"))
+  implicit val stringSerializer: Serializer[String] = new StringSerializer()
   val mf: MetricFactory[Gauge] = Metrics.gaugeFactory
 
 
   "GettingStarted example" should "send messages to Kafka and use custom Prometheus metric to verify behaviour" in {
     //given
-    val topic: String = "input"
-    val testMessage = new ProducerRecord[Array[Byte], Array[Byte]](topic, "test message".getBytes)
+    val topic = "input"
+    val testMessage = KafkaMessage(topic, "test message").asRecord()
     val query = PromQl[Gauge](s"""kafka_server_BrokerTopicMetrics_OneMinuteRate{name="MessagesInPerSec",topic="$topic"}""", mf)
     val kafkaTopicMessagesRate = PrometheusMetric[Gauge](query)
 

--- a/src/main/scala/io/woodenmill/penstock/backends/kafka/KafkaMessage.scala
+++ b/src/main/scala/io/woodenmill/penstock/backends/kafka/KafkaMessage.scala
@@ -1,0 +1,23 @@
+package io.woodenmill.penstock.backends.kafka
+
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.serialization.Serializer
+
+object KafkaMessage {
+  def apply[V](topic: String, value: V): KafkaMessage[V,V] = KafkaMessage[V,V](topic, None, value)
+  def apply[K,V](topic: String, key: K, value: V): KafkaMessage[K,V] = KafkaMessage[K,V](topic, Option(key), value)
+}
+
+case class KafkaMessage[K,V](topic: String, key: Option[K], value: V) {
+
+  def asRecord()(implicit keySer: Serializer[K], valSer: Serializer[V]): ProducerRecord[Array[Byte], Array[Byte]] = {
+    val valueBytes = valSer.serialize(topic, value)
+    key match {
+      case Some(k) =>
+        val keyBytes = keySer.serialize(topic, k)
+        new ProducerRecord(topic, keyBytes, valueBytes)
+      case None =>
+        new ProducerRecord(topic, valueBytes)
+    }
+  }
+}

--- a/src/test/scala/io/woodenmill/penstock/backends/kafka/KafkaBackendSpec.scala
+++ b/src/test/scala/io/woodenmill/penstock/backends/kafka/KafkaBackendSpec.scala
@@ -6,9 +6,12 @@ import io.woodenmill.penstock.LoadRunner
 import io.woodenmill.penstock.testutils.{Ports, Spec}
 import net.manub.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
 import org.apache.kafka.clients.producer.ProducerRecord
-import org.apache.kafka.common.serialization.StringDeserializer
+import org.apache.kafka.common.serialization.{Deserializer, Serializer, StringDeserializer}
 import org.scalatest.BeforeAndAfterAll
+import com.ovoenergy.kafka.serialization.circe._
+import io.circe.generic.auto._
 
+import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.Try
 
@@ -18,6 +21,8 @@ class KafkaBackendSpec extends Spec with EmbeddedKafka with BeforeAndAfterAll {
   val kafkaPort: Int = Ports.nextAvailablePort()
   val bootstrapServer: String = s"localhost:$kafkaPort"
 
+  val system = ActorSystem()
+  val mat = ActorMaterializer()(system)
   val kafkaBackend: KafkaBackend = KafkaBackend(bootstrapServer)
   implicit val stringDeserializer = new StringDeserializer()
   implicit val kafkaConfig = EmbeddedKafkaConfig(kafkaPort = kafkaPort, zooKeeperPort = Ports.nextAvailablePort())
@@ -28,6 +33,7 @@ class KafkaBackendSpec extends Spec with EmbeddedKafka with BeforeAndAfterAll {
   }
 
   override protected def afterAll(): Unit = {
+    Await.ready(system.terminate(), 5.seconds)
     kafkaBackend.shutdown()
     EmbeddedKafka.stop()
   }
@@ -42,14 +48,27 @@ class KafkaBackendSpec extends Spec with EmbeddedKafka with BeforeAndAfterAll {
   }
 
   it should "integrate with Load Runner" in {
-    val system = ActorSystem()
-    val mat = ActorMaterializer()(system)
     val message = new ProducerRecord[Array[Byte], Array[Byte]](topic, "from-runner".getBytes)
 
     val runnerFinished = LoadRunner(message, 1.milli, 1).run()(kafkaBackend, mat)
 
     whenReady(runnerFinished) { _ =>
       consumeFirstStringMessageFrom(topic) shouldBe "from-runner"
+    }
+  }
+
+  it should "integrate with custom serializers" in {
+    case class User(name: String, property: Double)
+    implicit val userSer: Serializer[User] = circeJsonSerializer[User]
+
+    val user = User("Dominic", 34.3)
+    val message = KafkaMessage(topic, user).asRecord()
+
+    val runnerFinished = LoadRunner(message, 1.milli, 1).run()(kafkaBackend, mat)
+
+    whenReady(runnerFinished) { _ =>
+      implicit val deserializer: Deserializer[User] = circeJsonDeserializer[User]
+      consumeFirstMessageFrom[User](topic) shouldBe user
     }
   }
 

--- a/src/test/scala/io/woodenmill/penstock/backends/kafka/KafkaMessageSpec.scala
+++ b/src/test/scala/io/woodenmill/penstock/backends/kafka/KafkaMessageSpec.scala
@@ -1,0 +1,52 @@
+package io.woodenmill.penstock.backends.kafka
+
+import com.ovoenergy.kafka.serialization.circe._
+import io.circe.generic.auto._
+import io.woodenmill.penstock.testutils.Spec
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.serialization.{IntegerDeserializer, IntegerSerializer, Serializer, StringSerializer}
+
+class KafkaMessageSpec extends Spec {
+  implicit val stringSer: Serializer[String] = new StringSerializer()
+  implicit val integerSer: Serializer[Integer] = new IntegerSerializer()
+
+  "KafkaMessageSpec" should "be easily converted to ProducerRecord" in {
+    val kafkaMessage = KafkaMessage("topic", "test message")
+
+    val record: ProducerRecord[Array[Byte], Array[Byte]] = kafkaMessage.asRecord()
+
+    record.topic() shouldBe "topic"
+    record.value() shouldBe "test message".getBytes
+  }
+
+  it should "accept different types as a value, for instance Integer" in {
+    val intDeserializer = new IntegerDeserializer()
+
+    val record = KafkaMessage("sometopic", new Integer(42)).asRecord()
+
+    intDeserializer.deserialize(record.topic, record.value) shouldBe 42
+  }
+
+  it should "accept a case class as a value" in {
+    case class User(age: Int, name: String)
+    implicit val userSer: Serializer[User] = circeJsonSerializer[User]
+    val userDes = circeJsonDeserializer[User]
+    val user = User(56, "Rose")
+
+    val record = KafkaMessage("sometopic", user).asRecord()
+
+    userDes.deserialize(record.topic, record.value()) shouldBe user
+  }
+
+  it should "allow to specify a message key" in {
+    val kafkaMessage = KafkaMessage("topic", "key", "value")
+
+    val record: ProducerRecord[Array[Byte], Array[Byte]] = kafkaMessage.asRecord()
+
+    record.topic() shouldBe "topic"
+    record.key() shouldBe "key".getBytes
+    record.value() shouldBe "value".getBytes
+  }
+
+
+}


### PR DESCRIPTION
Usage of ProducerRecord is verbose and overcomplicated since Kafka backend accepts Array[Byte] only. Kafka backend parameter type is correct, allows sending many messages, each can have a different type. Introducing KafkaMessage class simplify message creation by providing a clear API.