### PR TITLE
Implement new tool - Ascii Reporter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,7 @@ libraryDependencies += "io.circe" %% "circe-core" % circeVersion
 libraryDependencies += "io.circe" %% "circe-generic" % circeVersion
 libraryDependencies += "io.circe" %% "circe-parser" % circeVersion
 libraryDependencies += "org.typelevel" %% "cats-effect" % "0.10.1"
+libraryDependencies += "de.vandermeer" % "asciitable" % "0.3.2"
 
 libraryDependencies += "com.typesafe.akka" %% "akka-testkit" % "2.5.14" % Test
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5" % Test

--- a/src/it/resources/logback-test.xml
+++ b/src/it/resources/logback-test.xml
@@ -1,0 +1,12 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/src/it/scala/io/woodenmill/penstock/examples/GettingStartedSpec.scala
+++ b/src/it/scala/io/woodenmill/penstock/examples/GettingStartedSpec.scala
@@ -10,15 +10,19 @@ import io.woodenmill.penstock.Metrics.{Counter, Gauge}
 import io.woodenmill.penstock.backends.kafka.{KafkaBackend, KafkaMessage}
 import io.woodenmill.penstock.metrics.prometheus.PrometheusMetric._
 import io.woodenmill.penstock.metrics.prometheus.{PromQl, PrometheusConfig, PrometheusMetric}
+import io.woodenmill.penstock.report.ConsoleReport
 import org.apache.kafka.common.serialization.{Serializer, StringSerializer}
-import org.scalatest.{AsyncFlatSpec, Matchers}
+import org.scalatest.{FlatSpec, Matchers}
 
+import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration._
 
-class GettingStartedSpec extends AsyncFlatSpec with Matchers  {
+class GettingStartedSpec extends FlatSpec with Matchers {
 
   implicit val system: ActorSystem = ActorSystem("Getting-Started")
   implicit val mat: ActorMaterializer = ActorMaterializer()
+  implicit val ec: ExecutionContext = system.dispatcher
+
   implicit val kafkaBackend: KafkaBackend = KafkaBackend("localhost:9092")
   implicit val promConfig: PrometheusConfig = PrometheusConfig(new URI("localhost:9090"))
   implicit val stringSerializer: Serializer[String] = new StringSerializer()
@@ -30,8 +34,7 @@ class GettingStartedSpec extends AsyncFlatSpec with Matchers  {
   "GettingStarted example" should "send messages to Kafka and use custom Prometheus metric to verify behaviour" in {
     //given
     val testMessage = KafkaMessage(topic, "test message").asRecord()
-
-    val messageRateDefinition: IO[Gauge] = PrometheusMetric[Gauge](metricName ="messages rate", query = q)
+    val messageRateDefinition: IO[Gauge] = PrometheusMetric[Gauge](metricName = "messages rate", query = q)
     val recordErrorTotal: IO[Counter] = kafkaBackend.metrics().recordErrorTotal
     val recordSendTotal: IO[Counter] = kafkaBackend.metrics().recordSendTotal
 
@@ -39,11 +42,13 @@ class GettingStartedSpec extends AsyncFlatSpec with Matchers  {
     val loadFinished = LoadRunner(testMessage, duration = 2.minutes, throughput = 200).run()
 
     //then
-    loadFinished.map { _ =>
-      recordErrorTotal.unsafeRunSync().value shouldBe 0
-      recordSendTotal.unsafeRunSync().value shouldBe (24000L +- 1000L)
-      messageRateDefinition.unsafeRunSync().value shouldBe 200.0 +- 20.0
-    }
+    ConsoleReport(messageRateDefinition, recordSendTotal, recordErrorTotal).runEvery(10.seconds)
+
+    Await.ready(loadFinished, 5.minutes)
+
+    recordErrorTotal.unsafeRunSync().value shouldBe 0
+    recordSendTotal.unsafeRunSync().value shouldBe (24000L +- 1000L)
+    messageRateDefinition.unsafeRunSync().value shouldBe 200.0 +- 20.0
   }
 
 }

--- a/src/main/scala/io/woodenmill/penstock/report/AsciiTableFormatter.scala
+++ b/src/main/scala/io/woodenmill/penstock/report/AsciiTableFormatter.scala
@@ -1,0 +1,19 @@
+package io.woodenmill.penstock.report
+
+import de.vandermeer.asciitable.{AT_Context, AsciiTable}
+import de.vandermeer.asciithemes.u8.U8_Grids
+import io.woodenmill.penstock.Metric
+
+
+private[report] object AsciiTableFormatter {
+
+  def format(metrics: List[Metric[_]]): String = {
+    val asciiTable = new AsciiTable(new AT_Context().setGrid(U8_Grids.borderDoubleLight))
+    asciiTable.addRule()
+    asciiTable.addRow("Metric Name", "Metric Value")
+    asciiTable.addRule()
+    metrics.foreach(m => asciiTable.addRow(m.name, m.value.toString))
+    asciiTable.addRule()
+    asciiTable.render()
+  }
+}

--- a/src/main/scala/io/woodenmill/penstock/report/ConsoleReport.scala
+++ b/src/main/scala/io/woodenmill/penstock/report/ConsoleReport.scala
@@ -1,0 +1,45 @@
+package io.woodenmill.penstock.report
+
+import akka.actor.ActorSystem
+import cats.effect.IO
+import cats.implicits._
+import io.woodenmill.penstock.Metric
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.{FiniteDuration, _}
+
+
+case class ConsoleReport(metricIos: IO[Metric[_]]*) {
+
+  def runEvery(interval: FiniteDuration)(implicit system: ActorSystem, printer: Printer = ConsolePrinter()): Unit = {
+    implicit val ec: ExecutionContext = system.dispatcher
+
+    val report = metricIos
+      .map(io => io.attempt)
+      .toList.parSequence
+      .map(maybeMetrics => maybeMetrics.foldRight((List[Throwable](), List[Metric[_]]()))(spanEither))
+      .map { case (throwables, metrics) =>
+        printer.printLine(AsciiTableFormatter.format(metrics))
+        throwables.foreach(t => printer.printLine(s"Error: ${t.getMessage}"))
+      }
+
+    system.scheduler.schedule(0.seconds, interval) {
+      report.unsafeRunSync()
+    }
+  }
+
+  private def spanEither[A, B](either: Either[A, B], acc: (List[A], List[B])): (List[A], List[B]) = {
+    either match {
+      case Left(t) => (t :: acc._1, acc._2)
+      case Right(m) => (acc._1, m :: acc._2)
+    }
+  }
+}
+
+trait Printer {
+  def printLine(line: String): Unit
+}
+
+case class ConsolePrinter() extends Printer {
+  override def printLine(line: String): Unit = println(line)
+}

--- a/src/test/scala/io/woodenmill/penstock/report/AsciiTableFormatterSpec.scala
+++ b/src/test/scala/io/woodenmill/penstock/report/AsciiTableFormatterSpec.scala
@@ -1,0 +1,23 @@
+package io.woodenmill.penstock.report
+
+import io.woodenmill.penstock.Metrics.{Counter, Gauge}
+import io.woodenmill.penstock.testutils.Spec
+
+class AsciiTableFormatterSpec extends Spec {
+
+  "Table Formatter" should "convert list of metrics into formatted ASCII table" in {
+    val metrics = List(Counter(42, "counter", 0L), Gauge(2.3, "gauge", 0L))
+
+    val formatted = AsciiTableFormatter.format(metrics)
+
+    val expected =
+      """╒═══════════════════════════════════════╤══════════════════════════════════════╕
+        |│Metric Name                            │Metric Value                          │
+        |╞═══════════════════════════════════════╪══════════════════════════════════════╡
+        |│counter                                │42                                    │
+        |│gauge                                  │2.3                                   │
+        |╘═══════════════════════════════════════╧══════════════════════════════════════╛""".stripMargin
+    formatted shouldBe expected
+  }
+
+}

--- a/src/test/scala/io/woodenmill/penstock/report/ConsoleReportIntegratedSpec.scala
+++ b/src/test/scala/io/woodenmill/penstock/report/ConsoleReportIntegratedSpec.scala
@@ -1,0 +1,42 @@
+package io.woodenmill.penstock.report
+
+import akka.actor.ActorSystem
+import io.woodenmill.penstock.Metrics.Counter
+import io.woodenmill.penstock.metrics.prometheus.{PromQl, PrometheusConfig, PrometheusMetric}
+import io.woodenmill.penstock.testutils.{PromResponses, PrometheusIntegratedSpec, Spec}
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+
+class ConsoleReportIntegratedSpec extends Spec with PrometheusIntegratedSpec {
+
+  implicit val promConfig= PrometheusConfig(prometheusUri)
+  implicit val system = ActorSystem()
+  implicit val ec: ExecutionContext = ExecutionContext.Implicits.global
+
+  "Console Report" should "print metrics values fetched from Prometheus" in {
+    val metric = PrometheusMetric[Counter]("up", PromQl("up"))
+    val mockedPrinter = MockedPrinter()
+    configurePromStub("up", PromResponses.valid(1234L, "1478"), 200)
+
+    ConsoleReport(metric).runEvery(10.milli)(system, mockedPrinter)
+
+    eventually {
+      mockedPrinter.printed() should include("up")
+      mockedPrinter.printed() should include("1478")
+    }
+  }
+
+  it should "print error message when query is invalid and fetching metrics has filed" in {
+    val metric = PrometheusMetric[Counter]("up", PromQl("up"))
+    val mockedPrinter = MockedPrinter()
+    configurePromStub("up", PromResponses.noDataPoint, 200)
+
+    ConsoleReport(metric).runEvery(10.milli)(system, mockedPrinter)
+
+    eventually {
+      mockedPrinter.printed() should include("Error: Prometheus Response must have exactly one result. Correct PromQL query")
+    }
+  }
+
+}

--- a/src/test/scala/io/woodenmill/penstock/report/ConsoleReportSpec.scala
+++ b/src/test/scala/io/woodenmill/penstock/report/ConsoleReportSpec.scala
@@ -1,0 +1,98 @@
+package io.woodenmill.penstock.report
+
+import akka.actor.ActorSystem
+import cats.effect.IO
+import io.woodenmill.penstock.Metrics.{Counter, Gauge}
+import io.woodenmill.penstock.testutils.Spec
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+
+class ConsoleReportSpec extends Spec {
+
+  val system = ActorSystem()
+  implicit val ec: ExecutionContext = ExecutionContext.Implicits.global
+
+  "Report" should "print metrics names values" in {
+    val metric = IO(Counter(3, "the name", 1L))
+    val mockedPrinter = MockedPrinter()
+
+    ConsoleReport(metric).runEvery(10.milliseconds)(system, mockedPrinter)
+
+    eventually {
+      mockedPrinter.printed() should include("3")
+      mockedPrinter.printed() should include("the name")
+    }
+  }
+
+  it should "allow to pass many metrics" in {
+    val first = IO(Counter(44, "counter", 0L))
+    val second = IO(Gauge(3.0, "gauge", 1L))
+    val mockedPrinter = MockedPrinter()
+
+    ConsoleReport(first, second).runEvery(10.milliseconds)(system, mockedPrinter)
+
+    eventually {
+      mockedPrinter.printed() should include("counter")
+      mockedPrinter.printed() should include("gauge")
+    }
+  }
+
+  it should "fetch metrics value periodically" in {
+    val mockedPrinter = MockedPrinter()
+    val metricIO = StubIO[Counter]()
+      .and(Counter(12, "counter", 0L))
+      .and(Counter(13, "counter", 1000L))
+      .toIO()
+
+    ConsoleReport(metricIO).runEvery(10.milliseconds)(system, mockedPrinter)
+
+    eventually {
+      mockedPrinter.printed() should include("12")
+      mockedPrinter.printed() should include("13")
+    }
+  }
+
+  it should "survive metrics fetching failure" in {
+    val mockedPrinter = MockedPrinter()
+    val metricIO = StubIO[Counter]()
+      .and(() => throw new RuntimeException("error"))
+      .and(Counter(7, "now it works", 1000L))
+      .toIO()
+
+    ConsoleReport(metricIO).runEvery(10.milliseconds)(system, mockedPrinter)
+
+    eventually {
+      mockedPrinter.printed() should include("error")
+      mockedPrinter.printed() should include("now it works")
+    }
+  }
+}
+
+
+case class StubIO[T](input: List[() => T] = List()) {
+  private var results: List[() => T] = input
+
+  def and(m: T): StubIO[T] = this.and(() => m)
+
+  def and(m: () => T): StubIO[T] = StubIO(results ::: List(m))
+
+  def toIO(): IO[T] = IO {
+    results match {
+      case head :: Nil =>
+        head()
+      case head :: tail =>
+        this.results = tail
+        head()
+      case Nil => ???
+    }
+  }
+}
+
+case class MockedPrinter() extends Printer {
+  private val builder = new StringBuilder
+
+  override def printLine(line: String): Unit = builder.append(line).append("\n")
+
+  def printed(): String = builder.toString()
+}


### PR DESCRIPTION
Often performance tests takes more time to finish. Ascii Reporter was created to see the metrics values during the test.