### PR TITLE
Implement Kafka readiness check so LoadRunner can fail fast if Kafka is not ready

### DIFF
--- a/src/main/scala/io/woodenmill/penstock/backends/StreamingBackend.scala
+++ b/src/main/scala/io/woodenmill/penstock/backends/StreamingBackend.scala
@@ -2,4 +2,5 @@ package io.woodenmill.penstock.backends
 
 trait StreamingBackend[T] {
   def send(msg: T): Unit
+  def isReady: Boolean
 }

--- a/src/main/scala/io/woodenmill/penstock/backends/kafka/KafkaBackend.scala
+++ b/src/main/scala/io/woodenmill/penstock/backends/kafka/KafkaBackend.scala
@@ -8,7 +8,7 @@ import io.woodenmill.penstock.backends.StreamingBackend
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, ProducerRecord}
 import org.apache.kafka.common.serialization.ByteArraySerializer
 import org.apache.kafka.common.{Metric, MetricName}
-
+import scala.concurrent.duration._
 import scala.collection.JavaConverters._
 
 
@@ -28,4 +28,6 @@ case class KafkaBackend(bootstrapServers: String) extends StreamingBackend[Produ
   def metrics(): KafkaMetrics = KafkaMetrics(rawMetrics, producerClientId)
 
   private val rawMetrics: IO[Map[MetricName, Metric]] = IO {producer.metrics().asScala.toMap }
+
+  override def isReady: Boolean = KafkaReadiness.isReady(bootstrapServers, 5.second)
 }

--- a/src/main/scala/io/woodenmill/penstock/backends/kafka/KafkaReadiness.scala
+++ b/src/main/scala/io/woodenmill/penstock/backends/kafka/KafkaReadiness.scala
@@ -1,0 +1,36 @@
+package io.woodenmill.penstock.backends.kafka
+
+import java.util.Properties
+
+import io.woodenmill.penstock.util.Mesurements._
+import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig, DescribeClusterOptions}
+
+import scala.annotation.tailrec
+import scala.concurrent.duration._
+import scala.util.Try
+
+
+private[kafka] object KafkaReadiness {
+  type NumberOfBrokers = Int
+  private val options = new DescribeClusterOptions().timeoutMs(1000)
+
+  def isReady(bootstrapServers: String, timeout: FiniteDuration = 5.second): Boolean = {
+    val properties = new Properties { put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers) }
+    val adminClient = AdminClient.create(properties)
+    val fetchNumberOfBrokers = () => Try( adminClient.describeCluster(options).nodes().get().size()).toOption
+
+    check(fetchNumberOfBrokers, timeout)
+  }
+
+  @tailrec
+  def check(fetchNumberOfBrokers: () => Option[NumberOfBrokers], timeout: FiniteDuration): Boolean = {
+    val (queryTime, maybeNumberOfBrokers) = executionTime { fetchNumberOfBrokers() }
+
+    maybeNumberOfBrokers match {
+      case Some(numberOfBrokers) if numberOfBrokers >= 1 => true
+      case _ if timeout - queryTime <= Zero => false
+      case _ => check(fetchNumberOfBrokers, timeout - queryTime)
+    }
+  }
+
+}

--- a/src/main/scala/io/woodenmill/penstock/util/Mesurements.scala
+++ b/src/main/scala/io/woodenmill/penstock/util/Mesurements.scala
@@ -1,0 +1,18 @@
+package io.woodenmill.penstock.util
+
+import java.util.concurrent.TimeUnit.MILLISECONDS
+
+import scala.concurrent.duration.FiniteDuration
+
+object Mesurements {
+
+  val Zero = FiniteDuration(0, MILLISECONDS)
+
+  def executionTime[A](block: => A): (FiniteDuration, A) = {
+    val t0 = System.currentTimeMillis()
+    val result = block
+    val t1 = System.currentTimeMillis()
+    val elapsedTime = FiniteDuration(t1-t0, MILLISECONDS)
+    (elapsedTime, result)
+  }
+}

--- a/src/test/scala/io/woodenmill/penstock/LoadRunnerSpec.scala
+++ b/src/test/scala/io/woodenmill/penstock/LoadRunnerSpec.scala
@@ -58,5 +58,13 @@ class LoadRunnerSpec extends Spec with BeforeAndAfterAll {
     }
   }
 
+  it should "fail fast if load target is not ready" in {
+    val backend = mockedBackend[String](isReady = false)
+
+    val runnerResult = LoadRunner("some msg", duration = 1.second, throughput = 1).run()(backend, mat)
+
+    runnerResult.failed.futureValue shouldBe an[IllegalStateException]
+  }
+
   override protected def afterAll(): Unit = Await.ready(actorSystem.terminate(), atMost = 5.seconds)
 }

--- a/src/test/scala/io/woodenmill/penstock/backends/kafka/KafkaBackendSpec.scala
+++ b/src/test/scala/io/woodenmill/penstock/backends/kafka/KafkaBackendSpec.scala
@@ -99,6 +99,15 @@ class KafkaBackendSpec extends Spec with EmbeddedKafka with BeforeAndAfterAll {
     }
   }
 
+  "Kafka Backend Readiness" should "return true if Kafka is available" in {
+    kafkaBackend.isReady shouldBe true
+  }
+
+  it should "return false if Kafka is not available" in withNewKafkaBackend("127.1.2.3:9092") { backend =>
+    backend.isReady shouldBe false
+  }
+
+
   def withNewKafkaBackend(bootstrapServer: String)(f: KafkaBackend => Unit): Unit = {
     val backend = KafkaBackend(bootstrapServer)
     try f(backend)

--- a/src/test/scala/io/woodenmill/penstock/backends/kafka/KafkaReadinessSpec.scala
+++ b/src/test/scala/io/woodenmill/penstock/backends/kafka/KafkaReadinessSpec.scala
@@ -1,0 +1,40 @@
+package io.woodenmill.penstock.backends.kafka
+
+import io.woodenmill.penstock.testutils.Spec
+
+import scala.concurrent.duration._
+
+class KafkaReadinessSpec extends Spec {
+
+  "Kafka readiness" should "be true if there is one broker in a cluster" in {
+    val stubbedBrokersFetcher = () => Some(1)
+
+    val isReady = KafkaReadiness.check(stubbedBrokersFetcher, 1.millisecond)
+
+    isReady shouldBe true
+  }
+
+  it should "be true if there is more than one broker in a cluster" in {
+    val stubbedBrokersFetcher = () => Some(11)
+
+    val isReady = KafkaReadiness.check(stubbedBrokersFetcher, 1.millisecond)
+
+    isReady shouldBe true
+  }
+
+  it should "be false if there is no broker in a cluster" in {
+    val stubbedBrokersFetcher = () => Some(0)
+
+    val isReady = KafkaReadiness.check(stubbedBrokersFetcher, 1.millisecond)
+
+    isReady shouldBe false
+  }
+
+  it should "be false if it cannot connect to cluster" in {
+    val stubbedBrokersFetcher = () => None
+
+    val isReady = KafkaReadiness.check(stubbedBrokersFetcher, 1.millisecond)
+
+    isReady shouldBe false
+  }
+}

--- a/src/test/scala/io/woodenmill/penstock/testutils/TestBackends.scala
+++ b/src/test/scala/io/woodenmill/penstock/testutils/TestBackends.scala
@@ -7,13 +7,15 @@ import scala.concurrent.Future
 
 
 object TestBackends {
-  def doNothing[T](): StreamingBackend[T] = (_: T) => Future.successful(())
+  def doNothing[T](): StreamingBackend[T] = new StreamingBackend[T] {
+    override def send(msg: T): Unit = Future.successful(())
+    override def isReady: Boolean = true
+  }
 
-  def mockedBackend[T](): MockedBackend[T] = MockedBackend()
+  def mockedBackend[T](isReady: Boolean = true): MockedBackend[T] = MockedBackend(isReady)
 
-  case class MockedBackend[T]() extends StreamingBackend[T] {
+  case class MockedBackend[T](isReady: Boolean) extends StreamingBackend[T] {
     var messages: mutable.Buffer[T] = mutable.Buffer()
-
     override def send(msg: T): Unit = messages += msg
   }
 


### PR DESCRIPTION
Since LoadRunner bases on `fire and forget` to achieve the highest possible load, penstock needed a mechanism that allows fail fast if there is no connection to load target (for instance Kafka).
Closes #9 