### PR TITLE
Remove LoadRunner methods with eager parameters

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,6 +35,7 @@ libraryDependencies += "com.github.tomakehurst" % "wiremock" % "2.18.0" % Test
 libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3" % Test
 libraryDependencies += "com.ovoenergy" %% "kafka-serialization-core" % "0.3.11" % Test
 libraryDependencies += "com.ovoenergy" %% "kafka-serialization-circe" % "0.3.11" % Test
+libraryDependencies += "com.danielasfregola" %% "random-data-generator" % "2.6" % Test
 
 
 scalacOptions ++= Seq(
@@ -45,7 +46,8 @@ scalacOptions ++= Seq(
   "-Ywarn-dead-code",
   "-Ywarn-infer-any",
   "-Ywarn-unused:imports",
-  "-Ywarn-unused:implicits"
+  "-Ywarn-unused:implicits",
+  "-Ywarn-unused:params"
 )
 
 logBuffered in Test := false

--- a/src/it/scala/io/woodenmill/penstock/examples/GettingStartedSpec.scala
+++ b/src/it/scala/io/woodenmill/penstock/examples/GettingStartedSpec.scala
@@ -12,11 +12,12 @@ import io.woodenmill.penstock.backends.kafka._
 import io.woodenmill.penstock.metrics.prometheus.PrometheusMetric._
 import io.woodenmill.penstock.metrics.prometheus.{PromQl, PrometheusConfig, PrometheusMetric}
 import io.woodenmill.penstock.report.ConsoleReport
+import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.serialization.{Serializer, StringSerializer}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FlatSpec, Matchers}
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration._
 
 class GettingStartedSpec extends FlatSpec with Matchers with ScalaFutures {
@@ -56,6 +57,28 @@ class GettingStartedSpec extends FlatSpec with Matchers with ScalaFutures {
       recordSendTotal.unsafeRunSync().value shouldBe (24000L +- 1000L)
       kafkaMessageInRate.unsafeRunSync().value shouldBe 200.0 +- 20.0
     }
+  }
+
+
+  it should "show how to send random messages" in {
+    //give
+    def generateMessages(): List[ProducerRecord[Array[Byte], Array[Byte]]] = {
+      import io.circe.generic.auto._                                        //gives case class serializer
+      import com.ovoenergy.kafka.serialization.circe._                      //gives case class serializer
+      import com.danielasfregola.randomdatagenerator.RandomDataGenerator._  //to generate User
+
+      case class User(id: String, nickName: String, anotherString: String, somethingDifferent: Int)
+
+      val generatedUser: User = random[User]
+
+      List(createProducerRecord(topic, generatedUser)(circeJsonSerializer[User]))
+    }
+
+    //when
+    val load = kafkaLoadRunner.start(generateMessages _, duration = 1.second, throughput = 10)
+
+    //then
+    Await.ready(load, 5.seconds)
   }
 
 }

--- a/src/main/scala/io/woodenmill/penstock/LoadRunner.scala
+++ b/src/main/scala/io/woodenmill/penstock/LoadRunner.scala
@@ -11,15 +11,11 @@ import scala.concurrent.duration._
 
 case class LoadRunner[T](backend: StreamingBackend[T]) {
 
-  def start(toSend: List[T], duration: FiniteDuration, throughput: Int)(implicit mat: ActorMaterializer): Future[Done] = {
-    this.start(() => toSend, duration, throughput)(mat)
+  def start(toSend: () => T, duration: FiniteDuration, throughput: Int)(implicit mat: ActorMaterializer): Future[Done] = {
+    start(() => List(toSend()) , duration, throughput)
   }
 
-  def start(toSend: T, duration: FiniteDuration, throughput: Int)(implicit mat: ActorMaterializer): Future[Done] = {
-    this.start(() => List(toSend), duration, throughput)(mat)
-  }
-
-  def start(toSend: () => List[T], duration: FiniteDuration, throughput: Int)(implicit mat: ActorMaterializer): Future[Done] = {
+  def start(toSend: () => List[T], duration: FiniteDuration, throughput: Int)(implicit mat: ActorMaterializer, d: DummyImplicit): Future[Done] = {
 
     if(backend.isReady) {
       val (killSwitch, loadRunnerFinishedFuture) = Source.cycle[T](() => toSend().iterator)

--- a/src/test/scala/io/woodenmill/penstock/LoadRunnerDurationSpec.scala
+++ b/src/test/scala/io/woodenmill/penstock/LoadRunnerDurationSpec.scala
@@ -23,7 +23,7 @@ class LoadRunnerDurationSpec extends Spec with BeforeAndAfterAll {
   "Load Runner" should "run as long as configured duration" in {
     val duration: FiniteDuration = 1.hour
 
-    val loadFinished = LoadRunner(backend).start("some message", duration, throughput = 100)(mat)
+    val loadFinished = LoadRunner(backend).start(() => "some message", duration, throughput = 100)(mat)
 
     loadFinished.isCompleted shouldBe false
     manualTime.timePasses(1.hour)

--- a/src/test/scala/io/woodenmill/penstock/backends/kafka/KafkaBackendSpec.scala
+++ b/src/test/scala/io/woodenmill/penstock/backends/kafka/KafkaBackendSpec.scala
@@ -49,7 +49,7 @@ class KafkaBackendSpec extends Spec with EmbeddedKafka with BeforeAndAfterAll {
   it should "integrate with Load Runner" in {
     val message = new ProducerRecord[Array[Byte], Array[Byte]](topic, "from-runner".getBytes)
 
-    val runnerFinished = LoadRunner(kafkaBackend).start(message, 1.milli, 1)(mat)
+    val runnerFinished = LoadRunner(kafkaBackend).start(() => message, 1.milli, 1)(mat)
 
     whenReady(runnerFinished) { _ =>
       consumeFirstStringMessageFrom(topic) shouldBe "from-runner"
@@ -63,7 +63,7 @@ class KafkaBackendSpec extends Spec with EmbeddedKafka with BeforeAndAfterAll {
     val user = User("Dominic", 34.3)
     val message = createProducerRecord(topic, user)(userSer)
 
-    val runnerFinished = LoadRunner(kafkaBackend).start(message, 1.milli, 1)(mat)
+    val runnerFinished = LoadRunner(kafkaBackend).start(()=> message, 1.milli, 1)(mat)
 
     whenReady(runnerFinished) { _ =>
       implicit val deserializer: Deserializer[User] = circeJsonDeserializer[User]


### PR DESCRIPTION
This change removes two public methods from LoadRunner since they were error prone and confusing. It was easy to pass a function result instead of a function so LoadRunner was sending the same message over and over.

Closes #29 