### PR TITLE
Validate that throughput is a positive integer

### DIFF
--- a/src/main/scala/io/woodenmill/penstock/LoadRunner.scala
+++ b/src/main/scala/io/woodenmill/penstock/LoadRunner.scala
@@ -16,7 +16,7 @@ case class LoadRunner[T](backend: StreamingBackend[T]) {
   }
 
   def start(toSend: () => List[T], duration: FiniteDuration, throughput: Int)(implicit mat: ActorMaterializer, d: DummyImplicit): Future[Done] = {
-
+    assert(throughput > 0, "Throughput must be a positive integer")
     if(backend.isReady) {
       val (killSwitch, loadRunnerFinishedFuture) = Source.cycle[T](() => toSend().iterator)
         .throttle(throughput, per = 1.second)

--- a/src/test/scala/io/woodenmill/penstock/LoadRunnerSpec.scala
+++ b/src/test/scala/io/woodenmill/penstock/LoadRunnerSpec.scala
@@ -79,5 +79,15 @@ class LoadRunnerSpec extends Spec with BeforeAndAfterAll {
     runnerResult.failed.futureValue shouldBe an[IllegalStateException]
   }
 
+  it should "fail fast if given throughput is not a positive number" in {
+    val negativeThroughput = -100
+
+    val caught = intercept[AssertionError] {
+        LoadRunner(mockedBackend[String]()).start(() => "somemessage", duration = 1.milli, negativeThroughput)
+    }
+
+    caught.getMessage shouldBe "assertion failed: Throughput must be a positive integer"
+  }
+
   override protected def afterAll(): Unit = Await.ready(actorSystem.terminate(), atMost = 5.seconds)
 }


### PR DESCRIPTION
Akka Streams does this validation for us, however the error message is confusing and not related to throughput. An assertion with custom message is more helpful for a user.

As a part of this PR I played with [Refined library](https://github.com/fthomas/refined). It's a library that allows to validate a value on compilation time. The first impression was very positive, however I've found it cumbersome to use from the user perspective. User can be intimidated by type `Int Refined Positive`. There is a auto conversion from Int to `Int Refined Positive`, however it requires an additional import (`import eu.timepit.refined.auto._`) line. I'm afraid it could be bad solution for users without experience with Refined. 