### PR TITLE
Refactor AsciiReport by moving out generic IO logic

### DIFF
--- a/src/main/scala/io/woodenmill/penstock/report/AsciiReport.scala
+++ b/src/main/scala/io/woodenmill/penstock/report/AsciiReport.scala
@@ -2,19 +2,15 @@ package io.woodenmill.penstock.report
 
 import cats.data.NonEmptyList
 import cats.effect.{ContextShift, IO}
-import cats.implicits._
 import io.woodenmill.penstock.Metric
+import io.woodenmill.penstock.util.IOOps.parallelAttempt
 
 object AsciiReport {
 
   type Report = String
 
   def apply(metricIOs: NonEmptyList[IO[Metric[_]]])(implicit cs: ContextShift[IO]): IO[Report] =
-    metricIOs
-      .map(io => io.attempt)
-      .parSequence
-      .map(throwablesAndMetrics => throwablesAndMetrics.toList.separate)
-      .map { case (throwables, metrics) =>
+    parallelAttempt(metricIOs.toList).map { case (throwables, metrics) =>
         val metricsReport = AsciiTableFormatter.format(metrics)
         val errorReport = throwables.map(t => s"Error: ${t.getMessage}").mkString("\n")
         s"""

--- a/src/main/scala/io/woodenmill/penstock/util/IOOps.scala
+++ b/src/main/scala/io/woodenmill/penstock/util/IOOps.scala
@@ -1,6 +1,7 @@
 package io.woodenmill.penstock.util
 
 import cats.effect.{ContextShift, IO, Timer}
+import cats.implicits._
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -18,5 +19,15 @@ object IOOps {
     }
   }
 
-  val printIO: String => IO[Unit] = term => IO { println(term) }
+  val printIO: String => IO[Unit] = term => IO {
+    println(term)
+  }
+
+
+  def parallelAttempt[T](ios: List[IO[T]])(implicit cs: ContextShift[IO]): IO[(List[Throwable], List[T])] = {
+    ios
+      .map(io => io.attempt)
+      .parSequence
+      .map(errorsAndSuccesses => errorsAndSuccesses.separate)
+  }
 }

--- a/src/test/scala/io/woodenmill/penstock/util/IOOpsSpec.scala
+++ b/src/test/scala/io/woodenmill/penstock/util/IOOpsSpec.scala
@@ -44,4 +44,17 @@ class IOOpsSpec extends Spec {
     noException should be thrownBy program.unsafeRunSync()
   }
 
+  "parallelAttempt" should "return list of errors and list of values" in {
+    val ex = new RuntimeException()
+    val input = List(IO(1), IO(2), IO(3), IO.raiseError(ex))
+
+    val output = IOOps.parallelAttempt[Int](input).unsafeRunSync()
+
+    output shouldBe (List(ex), List(1,2,3))
+  }
+
+  it should "handle empty input list" in {
+    IOOps.parallelAttempt[String](List()).unsafeRunSync() shouldBe (List(), List())
+  }
+
 }


### PR DESCRIPTION
A method called parallelAttempt is extracted and move to IO Ops object. By doing this the only logic left inside AsciiReport is formatting logic.